### PR TITLE
Add 'Client' class to send request to a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+# legionth/http-client-react
+
+HTTP client written in PHP on top of ReactPHP.
+
+**Table of Contents**
+* [Usage](#usage)
+* [Install](#install)
+* [License](#license)
+
+## Usage
+
+The client is responsible to send HTTP requests and receive the HTTP response
+from the server.
+
+This library uses [PSR-7](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md)
+objects to make it easier to handle the HTTP-Messsages.
+
+```php
+$uri = 'tcp://httpbin.org:80';
+$request = new Request('GET', 'http://httpbin.org');
+
+$promise = $client->request($uri, $request);
+```
+
+It could take some time until the response is transferred from the server
+to the client.
+For this reason the `request`-method will return a
+[ReactPHP promise](https://github.com/reactphp/promise).
+
+The promise will result in a
+[PSR-7 response object](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#33-psrhttpmessageresponseinterface)
+
+```php
+$promise = $client->request($uri, $request);
+$promise->then(
+    function (\Psr\Http\Message\ResponseInterface $response) {
+        echo 'Successfully received a response from the server:' . PHP_EOL;
+        echo RingCentral\Psr7\str($response);
+    },
+    function (\Exception $exception) {
+        echo $exception->getMessage() . PHP_EOL;
+    }
+);
+```
+
+The body of the response will always be an asynchronous
+[ReactPHP Stream](https://github.com/reactphp/stream).
+
+```php
+$promise = $client->request($uri, $request);
+$promise->then(
+    function (ResponseInterface $response) {
+        echo 'Successfully received a response from the server:' . PHP_EOL;
+        echo RingCentral\Psr7\str($response);
+
+        $body = $response->getBody();
+        $body->on('data', function ($data) {
+            echo "Body-Data: " . $data . PHP_EOL;
+        });
+
+        $body->on('end', function () {
+            exit(0);
+        });
+    },
+    function (\Exception $exception) {
+        echo $exception->getMessage() . PHP_EOL;
+    }
+);
+```
+
+The `end`-Event will be emmitted when the complete body of the HTTP response
+has been transferred to the client.
+In the example above it will exit the current script.
+
+## Install
+
+[New to Composer?](https://getcomposer.org/doc/00-intro.md)
+
+This will install the latest supported version:
+
+```bash
+$ composer require legionth/http-client-react:^0.1
+```
+
+## License
+
+MIT

--- a/examples/01-request-to-server.php
+++ b/examples/01-request-to-server.php
@@ -1,0 +1,36 @@
+<?php
+
+use RingCentral\Psr7\Response;
+use RingCentral\Psr7\Request;
+use Legionth\React\Http\Client;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = React\EventLoop\Factory::create();
+
+$client = new Client($loop);
+
+$uri = 'tcp://httpbin.org:80';
+$request = new Request('GET', 'http://httpbin.org');
+
+$promise = $client->request($uri, $request);
+$promise->then(
+    function (Response $response) {
+        echo 'Successfully received a response from the server:' . PHP_EOL;
+        echo RingCentral\Psr7\str($response);
+
+        $body = $response->getBody();
+        $body->on('data', function ($data) {
+            echo "Body-Data: " . $data . PHP_EOL;
+        });
+
+        $body->on('end', function () {
+            exit(0);
+        });
+    },
+    function (\Exception $exception) {
+        echo $exception->getMessage() . PHP_EOL;
+    }
+);
+
+$loop->run();

--- a/src/ChunkedDecoder.php
+++ b/src/ChunkedDecoder.php
@@ -1,0 +1,165 @@
+<?php
+namespace Legionth\React\Http;
+
+use Evenement\EventEmitter;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use React\Stream\Util;
+use Exception;
+
+/** @internal */
+class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
+{
+    const CRLF = "\r\n";
+    const MAX_CHUNK_HEADER_SIZE = 1024;
+
+    private $closed = false;
+    private $input;
+    private $buffer = '';
+    private $chunkSize = 0;
+    private $transferredSize = 0;
+    private $headerCompleted = false;
+
+    public function __construct(ReadableStreamInterface $input)
+    {
+        $this->input = $input;
+
+        $this->input->on('data', array($this, 'handleData'));
+        $this->input->on('end', array($this, 'handleEnd'));
+        $this->input->on('error', array($this, 'handleError'));
+        $this->input->on('close', array($this, 'close'));
+    }
+
+    public function isReadable()
+    {
+        return !$this->closed && $this->input->isReadable();
+    }
+
+    public function pause()
+    {
+        $this->input->pause();
+    }
+
+    public function resume()
+    {
+        $this->input->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        Util::pipe($this, $dest, $options);
+
+        return $dest;
+    }
+
+    public function close()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->buffer = '';
+
+        $this->closed = true;
+
+        $this->input->close();
+
+        $this->emit('close');
+        $this->removeAllListeners();
+    }
+
+    /** @internal */
+    public function handleEnd()
+    {
+        if (!$this->closed) {
+            $this->handleError(new \Exception('Unexpected end event'));
+        }
+    }
+
+    /** @internal */
+    public function handleError(\Exception $e)
+    {
+        $this->emit('error', array($e));
+        $this->close();
+    }
+
+    /** @internal */
+    public function handleData($data)
+    {
+        $this->buffer .= $data;
+
+        while ($this->buffer !== '') {
+            if (!$this->headerCompleted) {
+                $positionCrlf = strpos($this->buffer, static::CRLF);
+
+                if ($positionCrlf === false) {
+                    // Header shouldn't be bigger than 1024 bytes
+                    if (isset($this->buffer[static::MAX_CHUNK_HEADER_SIZE])) {
+                        $this->handleError(new \Exception('Chunk header size inclusive extension bigger than' . static::MAX_CHUNK_HEADER_SIZE. ' bytes'));
+                    }
+                    return;
+                }
+
+                $header = strtolower((string)substr($this->buffer, 0, $positionCrlf));
+                $hexValue = $header;
+
+                if (strpos($header, ';') !== false) {
+                    $array = explode(';', $header);
+                    $hexValue = $array[0];
+                }
+
+                if ($hexValue !== '') {
+                    $hexValue = ltrim($hexValue, "0");
+                    if ($hexValue === '') {
+                        $hexValue = "0";
+                    }
+                }
+
+                $this->chunkSize = hexdec($hexValue);
+                if (dechex($this->chunkSize) !== $hexValue) {
+                    $this->handleError(new \Exception($hexValue . ' is not a valid hexadecimal number'));
+                    return;
+                }
+
+                $this->buffer = (string)substr($this->buffer, $positionCrlf + 2);
+                $this->headerCompleted = true;
+                if ($this->buffer === '') {
+                    return;
+                }
+            }
+
+            $chunk = (string)substr($this->buffer, 0, $this->chunkSize - $this->transferredSize);
+
+            if ($chunk !== '') {
+                $this->transferredSize += strlen($chunk);
+                $this->emit('data', array($chunk));
+                $this->buffer = (string)substr($this->buffer, strlen($chunk));
+            }
+
+            $positionCrlf = strpos($this->buffer, static::CRLF);
+
+            if ($positionCrlf === 0) {
+                if ($this->chunkSize === 0) {
+                    $this->emit('end');
+                    $this->close();
+                    return;
+                }
+                $this->chunkSize = 0;
+                $this->headerCompleted = false;
+                $this->transferredSize = 0;
+                $this->buffer = (string)substr($this->buffer, 2);
+            }
+
+            if ($positionCrlf !== 0 && $this->chunkSize === $this->transferredSize && strlen($this->buffer) > 2) {
+                // the first 2 characters are not CLRF, send error event
+                $this->handleError(new \Exception('Chunk does not end with a CLRF'));
+                return;
+            }
+
+            if ($positionCrlf !== 0 && strlen($this->buffer) < 2) {
+                // No CLRF found, wait for additional data which could be a CLRF
+                return;
+            }
+        }
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Legionth\React\Http;
+
+use React\Promise\Promise;
+use React\EventLoop\LoopInterface;
+use React\SocketClient\Connector;
+use React\Socket\Connection;
+use Psr\Http\Message\RequestInterface;
+use React\SocketClient\ConnectorInterface;
+
+class Client
+{
+    private $connector;
+
+    public function __construct(LoopInterface $loop, ConnectorInterface $connector = null)
+    {
+        if ($connector === null) {
+            $connector = new Connector($loop);
+        }
+
+        $this->connector = $connector;
+    }
+
+    /**
+     * @param string $uri - the client will connect to this uri, e.g: tcp://google.com
+     * @param RequestInterface $request - request that will be sent to the server
+     * @return \React\Promise\Promise
+     */
+    public function request($uri, RequestInterface $request)
+    {
+        $connector = $this->connector;
+        $that = $this;
+
+        return new Promise(function ($resolve, $reject) use ($connector, $that, $uri, $request) {
+            $connector->connect($uri)->then(function ($connection) use ($that, $resolve, $reject, $request) {
+                $headerBuffer = '';
+                $listener = function ($data) use (&$headerBuffer, $that, $resolve, $reject, $connection, &$listener) {
+                    $headerBuffer .= $data;
+                    if (strpos($headerBuffer, "\r\n\r\n") !== false) {
+                        $connection->removeListener('data', $listener);
+                        // header is completed
+                        $fullHeader = (string)substr($headerBuffer, 0, strpos($headerBuffer, "\r\n\r\n") + 4);
+
+                        try {
+                            $response = \RingCentral\Psr7\parse_response($fullHeader);
+                        } catch (\Exception $ex) {
+                            return $reject($ex);
+                        }
+
+                        $stream = $connection;
+                        $contentLength = 0;
+                        // validate for 'Content-Length' or 'Transfer-Encoding'
+                        if ($response->hasHeader('Content-Length')) {
+                            $string = $response->getHeaderLine('Content-Length');
+
+                            $contentLength = (int)$string;
+                            if ((string)$contentLength !== (string)$string) {
+                                // Content-Length value is not an integer or not a single integer
+                                return $reject(new \InvalidArgumentException('The value of `Content-Length` is not valid'));
+                            }
+
+                            $stream = new LengthLimitedStream($stream, $contentLength);
+                        } else if ($response->hasHeader('Transfer-Encoding')) {
+                            if (strtolower($response->getHeaderLine('Transfer-Encoding')) !== 'chunked') {
+                                return $reject(new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding'));
+                            }
+
+                            $stream = new ChunkedDecoder($stream);
+
+                            $request = $response->withoutHeader('Transfer-Encoding');
+
+                            $contentLength = null;
+                        }
+
+                        $bodyStream = new HttpBodyStream($stream, $contentLength);
+                        $response = $response->withBody($bodyStream);
+                        $resolve($response);
+
+                        // remove header from $data, only body is left
+                        $data = (string)substr($data, strlen($fullHeader));
+                        if ($data !== '') {
+                            $connection->emit('data', array($data));
+                        }
+                    };
+                };
+
+                $connection->on('data', $listener);
+                $connection->write(\RingCentral\Psr7\str($request));
+            },
+            function (\Exception $ex) use ($reject) {
+                $reject($ex);
+            });
+        });
+    }
+}

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -1,0 +1,174 @@
+<?php
+namespace Legionth\React\Http;
+
+use Psr\Http\Message\StreamInterface;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use Evenement\EventEmitter;
+use React\Stream\Util;
+
+/**
+ * @internal
+ * Uses a StreamInterface from PSR-7 and a ReadableStreamInterface from ReactPHP
+ * to use PSR-7 objects and use ReactPHP streams
+ * This is class is used in `HttpServer` to stream the body of a response
+ * to the client. Because of this you can stream big amount of data without
+ * necessity of buffering this data. The data will be send directly to the client.
+ *
+ */
+class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableStreamInterface
+{
+    private $input;
+    private $closed = false;
+    private $size;
+
+    /**
+     * @param ReadableStreamInterface $input - Stream data from $stream as a body of a PSR-7 object4
+     * @param int|null $size - size of the data body
+     */
+    public function __construct(ReadableStreamInterface $input, $size)
+    {
+        $this->input = $input;
+        $this->size = $size;
+
+        $this->input->on('data', array($this, 'handleData'));
+        $this->input->on('end', array($this, 'handleEnd'));
+        $this->input->on('error', array($this, 'handleError'));
+        $this->input->on('close', array($this, 'close'));
+    }
+
+    public function isReadable()
+    {
+        return !$this->closed && $this->input->isReadable();
+    }
+
+    public function pause()
+    {
+        $this->input->pause();
+    }
+
+    public function resume()
+    {
+        $this->input->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        Util::pipe($this, $dest, $options);
+
+        return $dest;
+    }
+
+    public function close()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+
+        $this->input->close();
+
+        $this->emit('close');
+        $this->removeAllListeners();
+    }
+
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /** @ignore */
+    public function __toString()
+    {
+        return '';
+    }
+
+    /** @ignore */
+    public function detach()
+    {
+        return null;
+    }
+
+    /** @ignore */
+    public function tell()
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function eof()
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    /** @ignore */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function rewind()
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function isWritable()
+    {
+        return false;
+    }
+
+    /** @ignore */
+    public function write($string)
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function read($length)
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function getContents()
+    {
+        return '';
+    }
+
+    /** @ignore */
+    public function getMetadata($key = null)
+    {
+        return null;
+    }
+
+    /** @internal */
+    public function handleData($data)
+    {
+        $this->emit('data', array($data));
+    }
+
+    /** @internal */
+    public function handleError(\Exception $e)
+    {
+        $this->emit('error', array($e));
+        $this->close();
+    }
+
+    /** @internal */
+    public function handleEnd()
+    {
+        if (!$this->closed) {
+            $this->emit('end');
+            $this->close();
+        }
+    }
+}

--- a/src/LengthLimitedStream.php
+++ b/src/LengthLimitedStream.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Legionth\React\Http;
+
+use Evenement\EventEmitter;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use React\Stream\Util;
+
+/** @internal */
+class LengthLimitedStream extends EventEmitter implements ReadableStreamInterface
+{
+    private $stream;
+    private $closed = false;
+    private $encoder;
+    private $transferredLength = 0;
+    private $maxLength;
+
+    public function __construct(ReadableStreamInterface $stream, $maxLength)
+    {
+        $this->stream = $stream;
+        $this->maxLength = $maxLength;
+
+        $this->stream->on('data', array($this, 'handleData'));
+        $this->stream->on('end', array($this, 'handleEnd'));
+        $this->stream->on('error', array($this, 'handleError'));
+        $this->stream->on('close', array($this, 'close'));
+    }
+
+    public function isReadable()
+    {
+        return !$this->closed && $this->stream->isReadable();
+    }
+
+    public function pause()
+    {
+        $this->stream->pause();
+    }
+
+    public function resume()
+    {
+        $this->stream->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        Util::pipe($this, $dest, $options);
+
+        return $dest;
+    }
+
+    public function close()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+
+        $this->stream->close();
+
+        $this->emit('close');
+        $this->removeAllListeners();
+    }
+
+    /** @internal */
+    public function handleData($data)
+    {
+        if (($this->transferredLength + strlen($data)) > $this->maxLength) {
+            // Only emit data until the value of 'Content-Length' is reached, the rest will be ignored
+            $data = (string)substr($data, 0, $this->maxLength - $this->transferredLength);
+        }
+
+        if ($data !== '') {
+            $this->transferredLength += strlen($data);
+            $this->emit('data', array($data));
+        }
+
+        if ($this->transferredLength === $this->maxLength) {
+            // 'Content-Length' reached, stream will end
+            $this->emit('end');
+            $this->close();
+            $this->stream->removeListener('data', array($this, 'handleData'));
+        }
+    }
+
+    /** @internal */
+    public function handleError(\Exception $e)
+    {
+        $this->emit('error', array($e));
+        $this->close();
+    }
+
+    /** @internal */
+    public function handleEnd()
+    {
+        if (!$this->closed) {
+            $this->handleError(new \Exception('Unexpected end event'));
+        }
+    }
+
+}

--- a/tests/ChunkedDecoderTest.php
+++ b/tests/ChunkedDecoderTest.php
@@ -1,0 +1,480 @@
+<?php
+
+use React\Stream\ReadableStream;
+use Legionth\React\Http\ChunkedDecoder;
+
+class ChunkedDecoderTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->input = new ReadableStream();
+        $this->parser = new ChunkedDecoder($this->input);
+    }
+
+    public function testSimpleChunk()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('hello'));
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("5\r\nhello\r\n"));
+    }
+
+    public function testTwoChunks()
+    {
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n"));
+    }
+
+    public function testEnd()
+    {
+        $this->parser->on('end', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("0\r\n\r\n"));
+    }
+
+    public function testParameterWithEnd()
+    {
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
+        $this->parser->on('end', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n0\r\n\r\n"));
+    }
+
+    public function testInvalidChunk()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("bla\r\n"));
+    }
+
+    public function testNeverEnd()
+    {
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("0\r\n"));
+    }
+
+    public function testWrongChunkHex()
+    {
+        $this->parser->on('error', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+
+        $this->input->emit('data', array("2\r\na\r\n5\r\nhello\r\n"));
+    }
+
+    public function testSplittedChunk()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('welt'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("4\r\n"));
+        $this->input->emit('data', array("welt\r\n"));
+    }
+
+    public function testSplittedHeader()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('welt'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());#
+        $this->parser->on('error', $this->expectCallableNever());
+
+
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\nwelt\r\n"));
+    }
+
+    public function testSplittedBoth()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('welt'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("welt\r\n"));
+    }
+
+    public function testCompletlySplitted()
+    {
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('we', 'lt')));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("we"));
+        $this->input->emit('data', array("lt\r\n"));
+    }
+
+    public function testMixed()
+    {
+        $this->parser->on('data', $this->expectCallableConsecutive(3, array('we', 'lt', 'hello')));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("we"));
+        $this->input->emit('data', array("lt\r\n"));
+        $this->input->emit('data', array("5\r\nhello\r\n"));
+    }
+
+    public function testBigger()
+    {
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('abcdeabcdeabcdea', 'hello')));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("1"));
+        $this->input->emit('data', array("0"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("abcdeabcdeabcdea\r\n"));
+        $this->input->emit('data', array("5\r\nhello\r\n"));
+    }
+
+    public function testOneUnfinished()
+    {
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('bla', 'hello')));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("3\r\n"));
+        $this->input->emit('data', array("bla\r\n"));
+        $this->input->emit('data', array("5\r\nhello"));
+    }
+
+    public function testChunkIsBiggerThenExpected()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('hello'));
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("5\r\n"));
+        $this->input->emit('data', array("hello world\r\n"));
+    }
+
+    public function testHandleUnexpectedEnd()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('end');
+    }
+
+    public function testExtensionWillBeIgnored()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('bla'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("3;hello=world;foo=bar\r\nbla"));
+    }
+
+    public function testChunkHeaderIsTooBig()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $data = '';
+        for ($i = 0; $i < 1025; $i++) {
+            $data .= 'a';
+        }
+        $this->input->emit('data', array($data));
+    }
+
+    public function testChunkIsMaximumSize()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $data = '';
+        for ($i = 0; $i < 1024; $i++) {
+            $data .= 'a';
+        }
+        $data .= "\r\n";
+
+        $this->input->emit('data', array($data));
+    }
+
+    public function testLateCrlf()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('late'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("4\r\nlate"));
+        $this->input->emit('data', array("\r"));
+        $this->input->emit('data', array("\n"));
+    }
+
+    public function testNoCrlfInChunk()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('no'));
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("2\r\nno crlf"));
+    }
+
+    public function testNoCrlfInChunkSplitted()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('no'));
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("2\r\n"));
+        $this->input->emit('data', array("no"));
+        $this->input->emit('data', array("further"));
+        $this->input->emit('data', array("clrf"));
+    }
+
+    public function testEmitEmptyChunkBody()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("2\r\n"));
+        $this->input->emit('data', array(""));
+        $this->input->emit('data', array(""));
+    }
+
+    public function testEmitCrlfAsChunkBody()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith("\r\n"));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("2\r\n"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("\r\n"));
+    }
+
+    public function testNegativeHeader()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("-2\r\n"));
+    }
+
+    public function testHexDecimalInBodyIsPotentialThread()
+    {
+        $this->parser->on('data', $this->expectCallableOnce('test'));
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("4\r\ntest5\r\nworld"));
+    }
+
+    public function testHexDecimalInBodyIsPotentialThreadSplitted()
+    {
+        $this->parser->on('data', $this->expectCallableOnce('test'));
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("test"));
+        $this->input->emit('data', array("5"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("world"));
+    }
+
+    public function testEmitSingleCharacter()
+    {
+        $this->parser->on('data', $this->expectCallableConsecutive(4, array('t', 'e', 's', 't')));
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableOnce());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $array = str_split("4\r\ntest\r\n0\r\n\r\n");
+
+        foreach ($array as $character) {
+            $this->input->emit('data', array($character));
+        }
+    }
+
+    public function testHandleError()
+    {
+        $this->parser->on('error', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+
+        $this->input->emit('error', array(new \RuntimeException()));
+
+        $this->assertFalse($this->parser->isReadable());
+    }
+
+    public function testPauseStream()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input->expects($this->once())->method('pause');
+
+        $parser = new ChunkedDecoder($input);
+        $parser->pause();
+    }
+
+    public function testResumeStream()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input->expects($this->once())->method('pause');
+
+        $parser = new ChunkedDecoder($input);
+        $parser->pause();
+        $parser->resume();
+    }
+
+    public function testPipeStream()
+    {
+        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+
+        $ret = $this->parser->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
+
+    public function testHandleClose()
+    {
+        $this->parser->on('close', $this->expectCallableOnce());
+
+        $this->input->close();
+        $this->input->emit('end', array());
+
+    	$this->assertFalse($this->parser->isReadable());
+    }
+
+    public function testOutputStreamCanCloseInputStream()
+    {
+        $input = new ReadableStream();
+        $input->on('close', $this->expectCallableOnce());
+
+        $stream = new ChunkedDecoder($input);
+        $stream->on('close', $this->expectCallableOnce());
+
+        $stream->close();
+
+        $this->assertFalse($input->isReadable());
+    }
+
+    public function testLeadingZerosWillBeIgnored()
+    {
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'hello world')));
+        $this->parser->on('error', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("00005\r\nhello\r\n"));
+        $this->input->emit('data', array("0000b\r\nhello world\r\n"));
+    }
+
+    public function testLeadingZerosInEndChunkWillBeIgnored()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("0000\r\n\r\n"));
+    }
+
+    public function testLeadingZerosInInvalidChunk()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("0000hello\r\n\r\n"));
+    }
+
+    public function testEmptyHeaderLeadsToError()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("\r\n\r\n"));
+    }
+
+    public function testEmptyHeaderAndFilledBodyLeadsToError()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("\r\nhello\r\n"));
+    }
+
+    public function testUpperCaseHexWillBeHandled()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('0123456790'));
+        $this->parser->on('error', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("A\r\n0123456790\r\n"));
+    }
+
+    public function testLowerCaseHexWillBeHandled()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('0123456790'));
+        $this->parser->on('error', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("a\r\n0123456790\r\n"));
+    }
+
+    public function testMixedUpperAndLowerCaseHexValuesInHeaderWillBeHandled()
+    {
+        $data = str_repeat('1', (int)hexdec('AA'));
+
+        $this->parser->on('data', $this->expectCallableOnceWith($data));
+        $this->parser->on('error', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("aA\r\n" . $data . "\r\n"));
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,227 @@
+<?php
+
+use Legionth\React\Http\Client;
+use React\SocketClient\ConnectorInterface;
+use RingCentral\Psr7\Request;
+use React\Promise\Promise;
+use Psr\Http\Message\ResponseInterface;
+use function RingCentral\Psr7\str;
+
+class ClientTest extends TestCase
+{
+    private $client;
+    private $connector;
+    private $connection;
+    private $loop;
+    private $uri;
+    private $promise;
+
+    public function setUp()
+    {
+        $this->uri = 'tcp://reactphp.org';
+        $this->loop = new React\EventLoop\StreamSelectLoop();
+
+        $this->connector = $this->getMockBuilder('React\SocketClient\ConnectorInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->connection = $this->getMockBuilder('React\Socket\Connection')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                array(
+                    'write',
+                    'end',
+                    'close',
+                    'pause',
+                    'resume',
+                    'isReadable',
+                    'isWritable'
+                )
+            )
+            ->getMock();
+
+        $connection = &$this->connection;
+        $this->promise = new Promise(function ($resolve, $reject) use (&$connection) {
+            $resolve($connection);
+        });
+    }
+
+    public function testClientRequestWillReturnPromise()
+    {
+        $this->connector->expects($this->once())
+            ->method('connect')
+            ->with($this->equalTo($this->uri))
+            ->willReturn($this->promise);
+
+        $client = new Client($this->loop, $this->connector);
+
+        $responsePromise = $client->request($this->uri, new Request('GET', 'http://reactphp.org'));
+
+        $this->assertInstanceOf(Promise::class, $responsePromise);
+    }
+
+    public function testClientRequestWillResultInResponse()
+    {
+        $this->connector->expects($this->once())
+            ->method('connect')
+            ->with($this->equalTo($this->uri))
+            ->willReturn($this->promise);
+
+        $client = new Client($this->loop, $this->connector);
+
+        $data = '';
+        $responsePromise = $client->request($this->uri, new Request('GET', 'http://reactphp.org'));
+        $responsePromise->then(function (ResponseInterface $response) use (&$data) {
+            $data = str($response);
+        });
+
+        $this->connection->emit('data', array("HTTP/1.1 200 OK\r\n\r\n"));
+        $this->assertEquals("HTTP/1.1 200 OK\r\n\r\n", $data);
+    }
+
+    public function testTransferEncodingResponseWillEmitEndEvent()
+    {
+        $this->connector->expects($this->once())
+            ->method('connect')
+            ->with($this->equalTo($this->uri))
+            ->willReturn($this->promise);
+
+        $client = new Client($this->loop, $this->connector);
+
+        $data = '';
+        $expectCalledOnce = $this->expectCallableOnce();
+
+        $responsePromise = $client->request($this->uri, new Request('GET', 'http://reactphp.org'));
+        $responsePromise->then(function (ResponseInterface $response) use (&$data, $expectCalledOnce) {
+            $response->getBody()->on('data', function ($chunk) use (&$data){
+                $data = $chunk;
+            });
+            $response->getBody()->on('end', $expectCalledOnce);
+        });
+
+        $this->connection->emit('data', array("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n"));
+        $this->assertEquals('hello', $data);
+    }
+
+    public function testContentLengthResponseWillEmitEndEvent()
+    {
+        $this->connector->expects($this->once())
+            ->method('connect')
+            ->with($this->equalTo($this->uri))
+            ->willReturn($this->promise);
+
+        $client = new Client($this->loop, $this->connector);
+
+        $data = '';
+        $expectCalledOnce = $this->expectCallableOnce();
+
+        $responsePromise = $client->request($this->uri, new Request('GET', 'http://reactphp.org'));
+        $responsePromise->then(function (ResponseInterface $response) use (&$data, $expectCalledOnce) {
+            $response->getBody()->on('data', function ($chunk) use (&$data){
+                $data = $chunk;
+            });
+            $response->getBody()->on('end', $expectCalledOnce);
+        });
+
+        $this->connection->emit('data', array("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello"));
+        $this->assertEquals('hello', $data);
+    }
+
+    public function testInvalidContentLengthWillResultInInvalidException()
+    {
+        $this->connector->expects($this->once())
+            ->method('connect')
+            ->with($this->equalTo($this->uri))
+            ->willReturn($this->promise);
+
+        $client = new Client($this->loop, $this->connector);
+
+        $result = null;
+
+        $responsePromise = $client->request($this->uri, new Request('GET', 'http://reactphp.org'));
+        $responsePromise->then(
+            $this->expectCallableNever(),
+            function ($exception) use (&$result) {
+                $result = $exception;
+            }
+        );
+
+        $this->connection->emit('data', array("HTTP/1.1 200 OK\r\nContent-Length: bla\r\n\r\nhello"));
+        $this->assertInstanceOf(InvalidArgumentException::class, $result);
+    }
+
+    public function testInvalidTransferEncodingWillResultInInvalidException()
+    {
+        $this->connector->expects($this->once())
+            ->method('connect')
+            ->with($this->equalTo($this->uri))
+            ->willReturn($this->promise);
+
+        $client = new Client($this->loop, $this->connector);
+
+        $result = null;
+
+        $responsePromise = $client->request($this->uri, new Request('GET', 'http://reactphp.org'));
+        $responsePromise->then(
+            $this->expectCallableNever(),
+            function ($exception) use (&$result) {
+                $result = $exception;
+            }
+        );
+
+        $this->connection->emit('data', array("HTTP/1.1 200 OK\r\nTransfer-Encoding: bla\r\n\r\n5\r\nhello\r\n0\r\n\r\n"));
+        $this->assertInstanceOf(InvalidArgumentException::class, $result);
+    }
+
+    public function testFailingConnectionReturnsException()
+    {
+        $connector = $this->getMockBuilder('React\SocketClient\ConnectorInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $promise = new Promise(function ($resolve, $reject) {
+            $reject(new Exception());
+        });
+
+        $connector->expects($this->once())
+            ->method('connect')
+            ->with($this->equalTo($this->uri))
+            ->willReturn($promise);
+
+        $client = new Client($this->loop, $connector);
+
+        $responsePromise = $client->request($this->uri, new Request('GET', 'http://reactphp.org'));
+        $responsePromise->then(
+            $this->expectCallableNever(),
+            function ($exception) use (&$result) {
+                $result = $exception;
+            }
+        );
+
+        $this->connection->emit('data', array("HTTP/1.1 200 OK\r\n\r\n"));
+        $this->assertInstanceOf(Exception::class, $result);
+    }
+
+    public function testInvalidResponseResultsInException()
+    {
+        $this->connector->expects($this->once())
+            ->method('connect')
+            ->with($this->equalTo($this->uri))
+            ->willReturn($this->promise);
+
+        $client = new Client($this->loop, $this->connector);
+
+        $result = null;
+
+        $responsePromise = $client->request($this->uri, new Request('GET', 'http://reactphp.org'));
+        $responsePromise->then(
+            $this->expectCallableNever(),
+            function ($exception) use (&$result) {
+                $result = $exception;
+            }
+        );
+
+        $this->connection->emit('data', array("blaHTTP/1.1 200 OK\r\n\r\n"));
+        $this->assertInstanceOf(InvalidArgumentException::class, $result);
+    }
+}

--- a/tests/HttpBodyStreamTest.php
+++ b/tests/HttpBodyStreamTest.php
@@ -1,0 +1,185 @@
+<?php
+
+use Legionth\React\Http\HttpBodyStream;
+use React\Stream\ReadableStream;
+
+class HttpBodyStreamTest extends TestCase
+{
+    private $input;
+    private $bodyStream;
+
+    public function setUp()
+    {
+        $this->input = new ReadableStream();
+        $this->bodyStream = new HttpBodyStream($this->input, null);
+    }
+
+    public function testDataEmit()
+    {
+        $this->bodyStream->on('data', $this->expectCallableOnce(array("hello")));
+        $this->input->emit('data', array("hello"));
+    }
+
+    public function testPauseStream()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input->expects($this->once())->method('pause');
+
+        $bodyStream = new HttpBodyStream($input, null);
+        $bodyStream->pause();
+    }
+
+    public function testResumeStream()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input->expects($this->once())->method('pause');
+
+        $bodyStream = new HttpBodyStream($input, null);
+        $bodyStream->pause();
+        $bodyStream->resume();
+    }
+
+    public function testPipeStream()
+    {
+        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+
+        $ret = $this->bodyStream->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
+
+    public function testHandleClose()
+    {
+        $this->bodyStream->on('close', $this->expectCallableOnce());
+
+        $this->input->close();
+        $this->input->emit('end', array());
+
+        $this->assertFalse($this->bodyStream->isReadable());
+    }
+
+    public function testStopDataEmittingAfterClose()
+    {
+        $bodyStream = new HttpBodyStream($this->input, null);
+        $bodyStream->on('close', $this->expectCallableOnce());
+        $this->bodyStream->on('data', $this->expectCallableOnce(array("hello")));
+
+        $this->input->emit('data', array("hello"));
+        $bodyStream->close();
+        $this->input->emit('data', array("world"));
+    }
+
+    public function testHandleError()
+    {
+        $this->bodyStream->on('error', $this->expectCallableOnce());
+        $this->bodyStream->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('error', array(new \RuntimeException()));
+
+        $this->assertFalse($this->bodyStream->isReadable());
+    }
+
+    public function testToString()
+    {
+        $this->assertEquals('', $this->bodyStream->__toString());
+    }
+
+    public function testDetach()
+    {
+        $this->assertEquals(null, $this->bodyStream->detach());
+    }
+
+    public function testGetSizeDefault()
+    {
+        $this->assertEquals(null, $this->bodyStream->getSize());
+    }
+
+    public function testGetSizeCustom()
+    {
+        $stream = new HttpBodyStream($this->input, 5);
+        $this->assertEquals(5, $stream->getSize());
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testTell()
+    {
+        $this->bodyStream->tell();
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testEof()
+    {
+        $this->bodyStream->eof();
+    }
+
+    public function testIsSeekable()
+    {
+        $this->assertFalse($this->bodyStream->isSeekable());
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testWrite()
+    {
+        $this->bodyStream->write('');
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testRead()
+    {
+        $this->bodyStream->read('');
+    }
+
+    public function testGetContents()
+    {
+        $this->assertEquals('', $this->bodyStream->getContents());
+    }
+
+    public function testGetMetaData()
+    {
+        $this->assertEquals(null, $this->bodyStream->getMetadata());
+    }
+
+    public function testIsReadable()
+    {
+        $this->assertTrue($this->bodyStream->isReadable());
+    }
+
+    public function testPause()
+    {
+        $this->bodyStream->pause();
+    }
+
+    public function testResume()
+    {
+        $this->bodyStream->resume();
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testSeek()
+    {
+        $this->bodyStream->seek('');
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testRewind()
+    {
+        $this->bodyStream->rewind();
+    }
+
+    public function testIsWriteable()
+    {
+        $this->assertFalse($this->bodyStream->isWritable());
+    }
+}

--- a/tests/LengthLimitedStreamTest.php
+++ b/tests/LengthLimitedStreamTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use Legionth\React\Http\LengthLimitedStream;
+use React\Stream\ReadableStream;
+
+class LengthLimitedStreamTest extends TestCase
+{
+    private $input;
+    private $stream;
+
+    public function setUp()
+    {
+        $this->input = new ReadableStream();
+    }
+
+    public function testSimpleChunk()
+    {
+        $stream = new LengthLimitedStream($this->input, 5);
+        $stream->on('data', $this->expectCallableOnceWith('hello'));
+        $stream->on('end', $this->expectCallableOnce());
+        $this->input->emit('data', array("hello world"));
+    }
+
+    public function testInputStreamKeepsEmitting()
+    {
+        $stream = new LengthLimitedStream($this->input, 5);
+        $stream->on('data', $this->expectCallableOnceWith('hello'));
+        $stream->on('end', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("hello world"));
+        $this->input->emit('data', array("world"));
+        $this->input->emit('data', array("world"));
+    }
+
+    public function testZeroLengthInContentLengthWillIgnoreEmittedDataEvents()
+    {
+        $stream = new LengthLimitedStream($this->input, 0);
+        $stream->on('data', $this->expectCallableNever());
+        $stream->on('end', $this->expectCallableOnce());
+        $this->input->emit('data', array("hello world"));
+    }
+
+    public function testHandleError()
+    {
+        $stream = new LengthLimitedStream($this->input, 0);
+        $stream->on('error', $this->expectCallableOnce());
+        $stream->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('error', array(new \RuntimeException()));
+
+        $this->assertFalse($stream->isReadable());
+    }
+
+    public function testPauseStream()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input->expects($this->once())->method('pause');
+
+        $stream = new LengthLimitedStream($input, 0);
+        $stream->pause();
+    }
+
+    public function testResumeStream()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input->expects($this->once())->method('pause');
+
+        $stream = new LengthLimitedStream($input, 0);
+        $stream->pause();
+        $stream->resume();
+    }
+
+    public function testPipeStream()
+    {
+        $stream = new LengthLimitedStream($this->input, 0);
+        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+
+        $ret = $stream->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
+
+    public function testHandleClose()
+    {
+        $stream = new LengthLimitedStream($this->input, 0);
+        $stream->on('close', $this->expectCallableOnce());
+
+        $this->input->close();
+        $this->input->emit('end', array());
+
+        $this->assertFalse($stream->isReadable());
+    }
+
+    public function testOutputStreamCanCloseInputStream()
+    {
+        $input = new ReadableStream();
+        $input->on('close', $this->expectCallableOnce());
+
+        $stream = new LengthLimitedStream($input, 0);
+        $stream->on('close', $this->expectCallableOnce());
+
+        $stream->close();
+
+        $this->assertFalse($input->isReadable());
+    }
+
+    public function testHandleUnexpectedEnd()
+    {
+        $stream = new LengthLimitedStream($this->input, 5);
+
+        $stream->on('data', $this->expectCallableNever());
+        $stream->on('close', $this->expectCallableOnce());
+        $stream->on('end', $this->expectCallableNever());
+        $stream->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('end');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,80 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+error_reporting(-1);
+
+class TestCase extends PHPUnit_Framework_TestCase
+{
+    protected function expectCallableNever()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->never())
+            ->method('__invoke');
+
+        return $mock;
+    }
+
+    protected function expectCallableOnce()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke');
+
+        return $mock;
+    }
+
+    protected function expectCallableOnceWith($value)
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->equalTo($value));
+
+        return $mock;
+    }
+
+    protected function expectCallableOnceParameter($type)
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->isInstanceOf($type));
+
+        return $mock;
+    }
+
+    /**
+     * @link https://github.com/reactphp/react/blob/master/tests/React/Tests/Socket/TestCase.php (taken from reactphp/react)
+     */
+    protected function createCallableMock()
+    {
+        return $this->getMock('CallableStub');
+    }
+
+    protected function expectCallableConsecutive($numberOfCalls, array $with)
+    {
+        $mock = $this->createCallableMock();
+
+        for ($i = 0; $i < $numberOfCalls; $i++) {
+            $mock
+            ->expects($this->at($i))
+            ->method('__invoke')
+            ->with($this->equalTo($with[$i]));
+        }
+
+        return $mock;
+    }
+}
+
+class CallableStub
+{
+    public function __invoke()
+    {
+    }
+}
+


### PR DESCRIPTION
This PR will add the `Client` class to the project. A object of `Client` uses a [PSR-7 Request object](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md) that will be sent to a HTTP-Server.
The response of the server will also be represented by a PSR-7 object. The body will always be a ReactPHP Stream. A explanation how you can use this is written in the README of this PR.

Streaming a request body is currently not supported, but will be in one of the next PRs.